### PR TITLE
Remove explicit lens definition in favor of regular accessors being lenses

### DIFF
--- a/test/active/clojure/record_test.cljc
+++ b/test/active/clojure/record_test.cljc
@@ -72,27 +72,27 @@
 (define-record-type ^{:doc "Lens example"} LensPare
   (lens-kons a b)
   lens-pare?
-  [(^{:doc "a field"} a lens-kar lens-kar-lens)
-   (^{:doc "b field"} b lens-kdr lens-kdr-lens)])
+  [^{:doc "a field"} a lens-kar
+   ^{:doc "b field"} b lens-kdr])
 
 (deftest pare-lens
-  (lens-laws-hold lens-kar-lens (lens-kons 1 2) 23 42)
-  (lens-laws-hold lens-kdr-lens (lens-kons 1 2) 23 42)
+  (lens-laws-hold lens-kar (lens-kons 1 2) 23 42)
+  (lens-laws-hold lens-kdr (lens-kons 1 2) 23 42)
   (is (= (lens-kons "a" 42)
-         (lens/shove (lens-kons 23 42) lens-kar-lens "a")))
+         (lens/shove (lens-kons 23 42) lens-kar "a")))
   (is (= (lens-kons 23 "b")
-         (lens/shove (lens-kons 23 42) lens-kdr-lens "b"))))
+         (lens/shove (lens-kons 23 42) lens-kdr "b"))))
 
 (define-record-type Quadruple
   (quadruple a b c d)
   quadruple?
-  [(a quadruple-one quadruple-one-lens)
+  [a quadruple-one
    b quadruple-two
-   (c quadruple-three quadruple-three-lens)
+   c quadruple-three
    d quadruple-four])
 
 (deftest quadruple-lens
-  (lens-laws-hold quadruple-one-lens (quadruple 'a 'b 'c 'd) 12 78)
-  (lens-laws-hold quadruple-three-lens (quadruple 'a 'b 'c 'd) 12 78)
+  (lens-laws-hold quadruple-one (quadruple 'a 'b 'c 'd) 12 78)
+  (lens-laws-hold quadruple-three (quadruple 'a 'b 'c 'd) 12 78)
   (is (= (quadruple 4 8 15 16)
-         (lens/shove (quadruple 108 8 15 16) quadruple-one-lens 4))))
+         (lens/shove (quadruple 108 8 15 16) quadruple-one 4))))


### PR DESCRIPTION
Spits out deprecation warning if explicit lens definition triple occurs in record definition