### PR TITLE
Improve lens performance

### DIFF
--- a/src/active/clojure/lens.cljc
+++ b/src/active/clojure/lens.cljc
@@ -200,14 +200,13 @@
 
 (defn pos
   "A lens over the nth element in a collection. Note that when shoving a
-  new value nils may be added before the given position, if the collection is smaller."
+  new value `nil`s may be added before the given position, if the collection is smaller."
   [n]
   (assert (number? n))
   (assert (>= n 0))
-  ;; there are probably more efficient implementations:
-  (if (= n 0)
-    head
-    (>> tail (pos (- n 1)))))
+  (apply >>
+         (conj (vec (repeat n tail))
+               head)))
 
 (def ^{:doc "A lens that views a sequence as a set."}
   as-set

--- a/src/active/clojure/lens.cljc
+++ b/src/active/clojure/lens.cljc
@@ -42,6 +42,10 @@
     (assoc data lens v)
     (lens data v)))
 
+(defn- throw-invalid-number-of-arguments-error [n]
+  (let [error-msg (str "invalid number of arguments (" n ") to lens")]
+    (throw (java.lang.IllegalArgumentException. error-msg))))
+
 (defrecord ExplicitLens
     ^{:private true}
   [yanker shover args]
@@ -53,9 +57,7 @@
                        (case (count apply-args)
                          1 (apply yanker (aget apply-args 0) args)
                          2 (apply shover (aget apply-args 0) (aget apply-args 1) args)
-                         (let [error-msg (str "invalid number of arguments (" (count args) ") to lens")]
-                           (throw #?(:clj (java.lang.IllegalArgumentException. error-msg))
-                                  #?(:cljs error-msg))))))]
+                         (throw-invalid-number-of-arguments-error (count apply-args)))))]
       :cljs [IFn
              (-invoke [this data] (apply yanker data args))
              (-invoke [this data v] (apply shover data v args))]))

--- a/src/active/clojure/lens.cljc
+++ b/src/active/clojure/lens.cljc
@@ -112,7 +112,7 @@
 (def
   ^{:doc "Identity lens, that just show a data structure as it is.
           It's also the neutral element of lens concatenation
-          reacl.lens/>>."}
+          `reacl.lens/>>`."}
   id (xmap identity identity))
 
 (defn- keyword-shove [data val key]
@@ -148,11 +148,12 @@
   "Returns a concatenation of lenses, so that the combination shows the
    value of the last one, in a data structure that the first one is put
    over."
-  ([] id)
-  ([& [lens-1 & remaining :as lenses]]
-   (if (empty? remaining)
-     lens-1
-     (lens comb-yank comb-shove (mapv lift-lens lenses)))))
+  [& lenses]
+  (let [non-trivial-lenses (remove #{id} lenses)]
+    (if (empty? (rest non-trivial-lenses))
+      (or (first non-trivial-lenses)
+          id)
+      (lens comb-yank comb-shove (mapv lift-lens non-trivial-lenses)))))
 
 (defn- default-yank [data dflt]
   (if (nil? data) dflt data))

--- a/test/active/clojure/lens_test.cljc
+++ b/test/active/clojure/lens_test.cljc
@@ -335,7 +335,21 @@
              (apply lens/id [:foo :bar]))))
     (testing "lenses with args"
       (is (= {:a :b :c 42}
-             (apply (lens/member :c) [{:a :b} 42]))))))
+             (apply (lens/member :c) [{:a :b} 42])))))
+  #?(:clj (testing "throws when called with the wrong number of arguments"
+            (is (thrown-with-msg? java.lang.IllegalArgumentException
+                                  #"arguments \(3\)"
+                                  (apply (lens/member :a) [{} 2 :too-many-args])))
+            (is (thrown-with-msg? java.lang.IllegalArgumentException
+                                  #"arguments \(0\)"
+                                  (apply (lens/member :a) []))))
+     :cljs (testing "throws when called with the wrong number of arguments"
+             (is (thrown-with-msg? js/Error
+                                   #"arity"
+                                   (apply (lens/member :a) [{} 2 :too-many-args])))
+             (is (thrown-with-msg? js/Error
+                                   #"arity"
+                                   (apply (lens/member :a) []))))))
 
 (deftest lens-composition-equality
   (is (= (lens/>> (lens/pos 3) lens/nel-head)

--- a/test/active/clojure/lens_test.cljc
+++ b/test/active/clojure/lens_test.cljc
@@ -239,7 +239,14 @@
            (lens/>>))))
   (testing "Composition of one lens is the lens itself"
     (is (= (lens/member :foo)
-           (lens/>> (lens/member :foo))))))
+           (lens/>> (lens/member :foo)))))
+  (testing "`lens/id` is the neutral element w.r.t. lens composition"
+    (is (= lens/nel-head
+           (lens/>> lens/nel-head
+                    lens/id)))
+    (is (= lens/nel-head
+           (lens/>> lens/id
+                    lens/nel-head)))))
 
 (deftest **
   (let [l (lens/** :a lens/id)]

--- a/test/active/clojure/lens_test.cljc
+++ b/test/active/clojure/lens_test.cljc
@@ -233,7 +233,13 @@
     (is (= "shmip"
            (lens/yank data l)))
     (is (= [{:a 1 :b 2} {:c [1 2 3] :a {"florb" "flubber"}}]
-           (lens/shove data l nil)))))
+           (lens/shove data l nil))))
+  (testing "Empty composition of lenses is `lens/id`"
+    (is (= lens/id
+           (lens/>>))))
+  (testing "Composition of one lens is the lens itself"
+    (is (= (lens/member :foo)
+           (lens/>> (lens/member :foo))))))
 
 (deftest **
   (let [l (lens/** :a lens/id)]


### PR DESCRIPTION
Adds a set of commits that aim to improve the performance of `active.clojure.lens` lenses.

- Composition of more than two lenses led to nested `ExplicitLens` records. Now only one record will be created at the outermost level, and use an improved implementation of `comb-shove`.
- Use a new internal record type (`ExplicitLensWithoutArgs`) for lenses created with `active.clojure.lens/lens` that don't take any "extra arguments" (see e.g. `active.clojure.lens/member`). The `IFn` implementation of this record does not need to call `apply`, which slowed down yanking and shoving in this "simple" case.