### PR TITLE
Update breaking changes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ A library with various basic utilities for programming with Clojure.
 [![Actions Status](https://github.com/active-group/active-clojure/workflows/Tests/badge.svg)](https://github.com/active-group/active-clojure/actions)
 [![cljdoc badge](https://cljdoc.org/badge/de.active-group/active-clojure)](https://cljdoc.org/d/de.active-group/active-clojure/CURRENT)
 
+### Breaking changes in version `0.40.0`
+
+- `active.clojure.monad/run-monadic-swiss-army` was renamed to
+  `active.clojure.monad/run-monadic`.  This change was introduced in
+  96216542d4b8953c8896f145f8004bb362c46be6.
+
 ### Breaking changes in version 0.38
 
 - For an RTD record `MyRecord`, `(MyRecord :meta)` will no longer

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ A library with various basic utilities for programming with Clojure.
 ### Breaking changes in version `0.40.0`
 
 - `active.clojure.monad/run-monadic-swiss-army` was renamed to
-  `active.clojure.monad/run-monadic`.  This change was introduced in
-  96216542d4b8953c8896f145f8004bb362c46be6.
+  `active.clojure.monad/run-monadic`.
 
 ### Breaking changes in version `0.38`
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A library with various basic utilities for programming with Clojure.
   `active.clojure.monad/run-monadic`.  This change was introduced in
   96216542d4b8953c8896f145f8004bb362c46be6.
 
-### Breaking changes in version 0.38
+### Breaking changes in version `0.38`
 
 - For an RTD record `MyRecord`, `(MyRecord :meta)` will no longer
   return a meta data map. Use `(meta #'MyRecord)` instead.


### PR DESCRIPTION
This PR contains only two quick fixes to the README:

- Mention breaking change that `run-monadic-swiss-army` was renamed to `run-monadic`
- Display all versions in `Breaking changes in ...` as `<code>`

Accepting this PR will resolve #46.